### PR TITLE
Removed Copy command in Docker File

### DIFF
--- a/ZLCBotCore/Dockerfile
+++ b/ZLCBotCore/Dockerfile
@@ -15,6 +15,5 @@ RUN dotnet publish "ZLCBotCore.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-COPY appsettings.json .
 
 ENTRYPOINT ["dotnet", "ZLCBotCore.dll"]


### PR DESCRIPTION
Fixed the Dockerfile error I was running into. We don't need to copy appsettings.json file because the entire directory gets copied when the docker file is built. 