### PR TITLE
Added Give Roles Slash Command

### DIFF
--- a/ZLCBotCore/Data/VatusaApi.cs
+++ b/ZLCBotCore/Data/VatusaApi.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using static ZLCBotCore.Models.VatusaData.VatusaUserModel;
+
+namespace ZLCBotCore.Data
+{
+    /// <summary>
+    /// Access to the VATUSA API. Note some information returned will be null unless a VATUSA API TOKEN is used.
+    /// </summary>
+    public class VatusaApi
+    {
+        /// <summary>
+        /// Get the User information from the users Discord Id
+        /// </summary>
+        /// <param name="MemberId">Users Discord Id</param>
+        /// <returns>VATUSA User Data Model</returns>
+        public static async Task<VatusaUserData?> GetVatusaUserInfo(ulong MemberId)
+        {
+            string url = $"https://api.vatusa.net/v2/user/{MemberId}?d";
+
+            using HttpClient httpClient = new();
+
+            try
+            {
+                string json = await httpClient.GetStringAsync(url);
+                VatusaUserData? userData = JsonSerializer.Deserialize<VatusaUserData>(json);
+                return userData;
+            }
+            catch (WebException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/ZLCBotCore/Models/VatusaData/VatusaUserModel.cs
+++ b/ZLCBotCore/Models/VatusaData/VatusaUserModel.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ZLCBotCore.Models.VatusaData
+{
+    public class VatusaUserModel
+    {
+
+        public class VatusaUserData
+        {
+            public UserInformation? data { get; set; }
+            public bool? testing { get; set; }
+        }
+
+        public class UserInformation
+        {
+            public int? cid { get; set; }
+            public string? fname { get; set; }
+            public string? lname { get; set; }
+            public string? email { get; set; }
+            public string? facility { get; set; }
+            public int? rating { get; set; }
+            public DateTime? created_at { get; set; }
+            public DateTime? updated_at { get; set; }
+            public bool? flag_needbasic { get; set; }
+            public bool? flag_xferOverride { get; set; }
+            public DateTime? facility_join { get; set; }
+            public bool? flag_homecontroller { get; set; }
+            public DateTime? lastactivity { get; set; }
+            public object? flag_broadcastOptedIn { get; set; }
+            public object? flag_preventStaffAssign { get; set; }
+            public bool? promotion_eligible { get; set; }
+            public object? transfer_eligible { get; set; }
+            public StaffRole[]? roles { get; set; }
+            public string? rating_short { get; set; }
+            public VisitingFacilities[]? visiting_facilities { get; set; }
+            public bool? isMentor { get; set; }
+            public bool? isSupIns { get; set; }
+            public DateTime? last_promotion { get; set; }
+        }
+
+        public class StaffRole
+        {
+            public int? id { get; set; }
+            public int? cid { get; set; }
+            public string? facility { get; set; }
+            public string? role { get; set; }
+            public DateTime? created_at { get; set; }
+        }
+
+        public class VisitingFacilities
+        {
+            public int? id { get; set;}
+            public int? cid { get; set;}
+            public string? facility { get; set;}
+            public string? created_at { get; set;}
+            public string? updated_at { get; set; }
+        }
+    }
+}

--- a/ZLCBotCore/Modules/SlashCommands/UserSlashCommands.cs
+++ b/ZLCBotCore/Modules/SlashCommands/UserSlashCommands.cs
@@ -1,0 +1,45 @@
+﻿using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZLCBotCore.Services;
+
+namespace ZLCBotCore.Modules.SlashCommands
+{
+    public class UserSlashCommands: InteractionModuleBase<SocketInteractionContext>
+    {
+        private readonly IServiceProvider _services;
+        private readonly IConfiguration _config;
+        private readonly DiscordSocketClient _discord;
+        private readonly ILogger _logger;
+
+        public UserSlashCommands(IServiceProvider services)
+        {
+            _services = services;
+            _config = _services.GetRequiredService<IConfiguration>();
+            _discord = _services.GetRequiredService<DiscordSocketClient>(); ;
+            _logger = _services.GetRequiredService<ILogger<UserSlashCommands>>();
+
+            _logger.LogDebug("Module: Loaded UserSlashCommands");
+        }
+
+        /// <summary>
+        /// Slash Command for Giving Roles/Permissions to the user performing the command.
+        /// </summary>
+        /// <returns>None</returns>
+        [SlashCommand("give-role", "Get discord roles/permissions. Your Discord account must be linked on the VATUSA website.")]
+        public async Task AssignRoles()
+        {
+            //await DeferAsync(ephemeral: true); // ephemeral means that only the person doing the command will see the message/response.
+            await DeferAsync();
+            var embed = await _services.GetRequiredService<RoleAssignmentService>().GiveRole((SocketGuildUser)Context.User);
+            await FollowupAsync(embed: embed.Build());
+        }
+    }
+}

--- a/ZLCBotCore/Modules/SlashCommands/UserSlashCommands.cs
+++ b/ZLCBotCore/Modules/SlashCommands/UserSlashCommands.cs
@@ -1,4 +1,5 @@
-﻿using Discord.Interactions;
+﻿using Discord;
+using Discord.Interactions;
 using Discord.WebSocket;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,10 +34,24 @@ namespace ZLCBotCore.Modules.SlashCommands
         /// Slash Command for Giving Roles/Permissions to the user performing the command.
         /// </summary>
         /// <returns>None</returns>
-        [SlashCommand("give-role", "Get discord roles/permissions. Your Discord account must be linked on the VATUSA website.")]
+        [SlashCommand("give-roles", "Get discord roles/permissions. Your Discord account must be linked on the VATUSA website.")]
         public async Task AssignRoles()
         {
             //await DeferAsync(ephemeral: true); // ephemeral means that only the person doing the command will see the message/response.
+
+            if (Context.Channel.Name != "role-assignment")
+            {
+                await DeferAsync(ephemeral: true);
+                _logger.LogDebug($"give-roles: {Context.User.Username} tried to run the command in {Context.Channel.Name}. This command is only accepted in channels named 'role-assignment'");
+                EmbedBuilder wrongChannelBuilder = new EmbedBuilder()
+                {
+                    Title = "Wrong Discord Channel Error",
+                    Description = "Please use the role-assignment channel to give yourself roles.",
+                    Color= Color.Red
+                };
+                await FollowupAsync(embed: wrongChannelBuilder.Build());
+            }
+            
             await DeferAsync();
             var embed = await _services.GetRequiredService<RoleAssignmentService>().GiveRole((SocketGuildUser)Context.User);
             await FollowupAsync(embed: embed.Build());

--- a/ZLCBotCore/Services/InteractionHandler.cs
+++ b/ZLCBotCore/Services/InteractionHandler.cs
@@ -1,0 +1,73 @@
+﻿using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ZLCBotCore.Services
+{
+    /// <summary>
+    /// Interaction handler for Slash commands and other Discord Interactions
+    /// </summary>
+    public class InteractionHandler
+    {
+        // Dependency Injection Services Required
+        private readonly IServiceProvider _services;
+        private readonly DiscordSocketClient _discord;
+        private readonly InteractionService _interactionCommands;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Constructor for Discord Interaction Handler
+        /// </summary>
+        /// <param name="services">Dependency Injection Service Provider</param>
+        public InteractionHandler(IServiceProvider services)
+        {
+            _services = services;
+            _discord = _services.GetRequiredService<DiscordSocketClient>();
+            _interactionCommands = _services.GetRequiredService<InteractionService>();
+            _logger = _services.GetRequiredService<ILogger<InteractionHandler>>();
+
+            // Subscribe to the Discord.Ready event
+            //_discord.Ready += InitializeAsync;
+
+            _logger.LogDebug("Loaded: InteractionHandler");
+        }
+
+        /// <summary>
+        /// Initialize the Interaction handler. This can only be called once the Discord.Ready event is called.
+        /// </summary>
+        /// <returns>None</returns>
+        public async Task InitializeAsync()
+        {
+            // Add the slash commands
+            await _interactionCommands.AddModulesAsync(Assembly.GetEntryAssembly(), _services);
+
+            _discord.InteractionCreated += HandleInteraction;
+        }
+
+        /// <summary>
+        /// Handle Slash Commands and execute them
+        /// </summary>
+        /// <param name="arg">Discord Socket Interaction</param>
+        /// <returns>None</returns>
+        private async Task HandleInteraction(SocketInteraction arg)
+        {
+            try
+            {
+                var context = new SocketInteractionContext(_discord, arg);
+                await _interactionCommands.ExecuteCommandAsync(context, _services);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Interaction Handler: " + ex.Message);
+                throw;
+            }
+        }
+    }
+}

--- a/ZLCBotCore/Services/RoleAssignmentService.cs
+++ b/ZLCBotCore/Services/RoleAssignmentService.cs
@@ -119,7 +119,7 @@ namespace ZLCBotCore.Services
 
             if (userModel == null) return false;
 
-            if (new string[] { "", "OBS" }.Contains(userModel.data?.rating_short))
+            if (new string[] { "OBS" }.Contains(userModel.data?.rating_short))
             {
                 return true;
             }

--- a/ZLCBotCore/Services/RoleAssignmentService.cs
+++ b/ZLCBotCore/Services/RoleAssignmentService.cs
@@ -1,0 +1,226 @@
+﻿using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZLCBotCore.Data;
+using static ZLCBotCore.Models.VatusaData.VatusaUserModel;
+
+namespace ZLCBotCore.Services
+{
+    public class RoleAssignmentService
+    {
+        private readonly IServiceProvider _services;
+        private readonly DiscordSocketClient _discord;
+        private readonly ILogger _logger;
+        private readonly VatusaApi _vatusaApi;
+
+        public RoleAssignmentService(IServiceProvider services)
+        {
+            _services = services;
+            _discord = _services.GetRequiredService<DiscordSocketClient>();
+            _logger = _services.GetRequiredService<ILogger<RoleAssignmentService>>();
+            _vatusaApi = _services.GetRequiredService<VatusaApi>();
+
+            // Handle discord events.
+            //_discord.UserJoined += UserJoined;
+
+            _logger.LogDebug("Loaded: RoleAssignmentService");
+        }
+
+        /// <summary>
+        /// Give specific roles/permissions to users that have their discord account linked to VATUSA
+        /// </summary>
+        /// <param name="User">Socket Guild User from Discord</param>
+        /// <param name="SendDM_OnVatusaNotFound">Send a direct message to the user stating their account's are not linked.</param>
+        /// <returns>Embed Builder showing New roles and nickname that was assigned to that user.</returns>
+        public async Task<EmbedBuilder> GiveRole(SocketGuildUser User, bool SendDM_OnVatusaNotFound = true)
+        {
+            EmbedBuilder embed = new()
+            {
+                Color = Color.Green,
+                Title = "Your roles have been assigned"
+            };
+
+            VatusaUserData? userModel = await VatusaApi.GetVatusaUserInfo(User.Id);
+
+            string guildName = User.Guild.Name;
+
+            if (userModel == null && SendDM_OnVatusaNotFound)
+            {
+                SocketGuildChannel rolesChannel = User.Guild.Channels.First(x => x.Name == "role-assignment");
+
+                string linkInstructions =
+                    $"Hello, I am an automated program that is here to help you get your `{guildName}` Discord permissions/roles setup.\n\n" +
+                    "To do this, I need you to sync your Discord account with the VATUSA Discord server; You may do this by going to your VATUSA profile https://vatusa.net/my/profile > “VATUSA Discord Link”.\n\n" +
+                    $"When you are complete, go to the <#{rolesChannel.Id}> channel in the `{guildName}` discord server and complete the `\\Give Roles` command.\n\n" +
+                    "If you are unable to do this, please private message one of the Administrators/Staff Members of the discord.";
+
+                await User.CreateDMChannelAsync().Result.SendMessageAsync(linkInstructions);
+                _logger.LogInformation($"No Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Not found in VATUSA, no roles were assigned.");
+
+                embed.Title = "Not Linked";
+                embed.Description = "Your Discord account is not linked on VATUSA. Link it here: \nhttps://vatusa.net/my/profile";
+                embed.Color = Color.Red;
+                return embed;
+            }
+
+            if (userModel == null) return new EmbedBuilder() { Title = "Not Linked", Color = Color.Red, Description = "Your Discord account is not linked on VATUSA. Link it here: \nhttps://vatusa.net/my/profile" };
+
+            List<string> addRoles = DetermineRoles(userModel);
+
+            if (addRoles.Count() > 0)
+            {
+                foreach (string roleName in addRoles)
+                {
+                    SocketRole? role = User.Guild.Roles.First(x => x.Name == roleName);
+                    if (role == null) continue;
+
+                    await User.AddRoleAsync(role);
+                    _logger.LogInformation($"Give Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Found user in VATUSA, user also is ZLC Neighbor; Assigned {role?.Name} role to user.");
+                    embed.Description += role?.Mention + " ";
+                }
+            }
+
+            var nickname = await ChangeNickname(User, userModel);
+
+            embed.Footer = new EmbedFooterBuilder() { Text = "Your new nickname is: " + nickname };
+
+            return embed;
+        }
+
+        private List<string> DetermineRoles(VatusaUserData userModel)
+        {
+            List<string> output = new List<string>();
+
+            if (userModel.data?.facility == "ZLC")
+            {
+                if (HasArtccStaffRole(userModel)) output.Add("Staff");
+                if (IsZLCSpecialist(userModel)) output.Add("ZLC Specialist");
+                if (IsZLCVisitor(userModel)) output.Add("ZLC Visitor");
+                if (IsZLCObserver(userModel)) output.Add("Observer");
+            }
+
+            if (IsZLCNeighbor(userModel)) output.Add("ZLC Neighbor");
+
+            if (output.Count() == 0) output.Add("Guest");
+
+            return output;
+        }
+
+        private bool IsZLCObserver(VatusaUserData userModel)
+        {
+            //        | 0 |   1  |   2 |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  |  11  |  12  |
+            // Ratings: "", "OBS", "S1", "S2", "S3", "C1", "C2", "C3", "I1", "I2", "I3", "SUP", "ADM"
+
+            if (userModel == null) return false;
+
+            if (new string[] { "", "OBS" }.Contains(userModel.data?.rating_short))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private bool IsZLCVisitor(VatusaUserData userModel)
+        {
+            if (userModel.data?.visiting_facilities == null) return false;
+
+            foreach (var visitingFacility in userModel.data?.visiting_facilities)
+            {
+                if (visitingFacility.facility == "ZLC")
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsZLCSpecialist(VatusaUserData userModel)
+        {
+            //        | 0 |   1  |   2 |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  |  11  |  12  |
+            // Ratings: "", "OBS", "S1", "S2", "S3", "C1", "C2", "C3", "I1", "I2", "I3", "SUP", "ADM"
+
+            if (userModel == null) return false;
+
+            if (new string[] { "S1", "S2", "S3", "C1", "C2", "C3", "I1", "I2", "I3", "SUP" }.Contains(userModel.data?.rating_short))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Change the Users Nickname. If the user has a "|" in their nickname only change it AFTER the pipe symbol
+        /// </summary>
+        /// <param name="User">Socket Guild User from discord.</param>
+        /// <param name="UserData">User Model from VATUSA API</param>
+        /// <returns>A string for what the user's nickname was changed to.</returns>
+        private async Task<string> ChangeNickname(SocketGuildUser User, VatusaUserData? UserData)
+        {
+            string newNickname = $"{UserData?.data?.fname} {UserData?.data?.lname} | {UserData?.data?.rating_short?.ToUpper()} | {UserData?.data?.facility}";
+
+            if (User.Nickname != null && User.Nickname.Contains('|'))
+            {
+                newNickname = User.Nickname[..User.Nickname.IndexOf("|")] + newNickname[newNickname.IndexOf("|")..];
+            }
+
+            try
+            {
+                _logger.LogInformation($"Nickname: Changing {User.Username} ({User.Id}) nickname -> from {User.Nickname} to {newNickname}");
+                await User.ModifyAsync(u => u.Nickname = newNickname);
+                return newNickname;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Missing Permissions"))
+                {
+                    _logger.LogWarning($"Missing Permissions: Could not change Nickname for {User.Username} ({User.Id}) in {User.Guild.Name}");
+                    return "I could not change your nickname.";
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Check for any staff roles in the User Model from VATUSA API
+        /// </summary>
+        /// <param name="userData">User Modle from VATUSA API</param>
+        /// <returns>True if the user has a staff role, otherwise returns false.</returns>
+        private bool HasArtccStaffRole(VatusaUserData userData)
+        {
+            if (userData == null) return false;
+
+            if (userData.data?.roles?.Length >= 1)
+            {
+                foreach (StaffRole role in userData.data.roles)
+                {
+                    if (role.facility == "ZLC" && new string[] { "ATM", "DATM", "TA", "EC", "FE", "WM" }.Contains(role.role))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+        
+        private bool IsZLCNeighbor(VatusaUserData userModel)
+        {
+            if (userModel == null) return false;
+
+            if (new string[] { "ZSE", "ZOA", "ZLA", "ZDV", "ZMP" }.Contains(userModel.data?.facility))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/ZLCBotCore/Services/RoleAssignmentService.cs
+++ b/ZLCBotCore/Services/RoleAssignmentService.cs
@@ -81,7 +81,7 @@ namespace ZLCBotCore.Services
                     if (role == null) continue;
 
                     await User.AddRoleAsync(role);
-                    _logger.LogInformation($"Give Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Found user in VATUSA, user also is ZLC Neighbor; Assigned {role?.Name} role to user.");
+                    _logger.LogInformation($"Give Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Found user in VATUSA; Assigned {role?.Name} role to user.");
                     embed.Description += role?.Mention + " ";
                 }
             }

--- a/ZLCBotCore/Services/RoleAssignmentService.cs
+++ b/ZLCBotCore/Services/RoleAssignmentService.cs
@@ -101,9 +101,10 @@ namespace ZLCBotCore.Services
             {
                 if (HasArtccStaffRole(userModel)) output.Add("Staff");
                 if (IsZLCSpecialist(userModel)) output.Add("ZLC Specialist");
-                if (IsZLCVisitor(userModel)) output.Add("ZLC Visitor");
                 if (IsZLCObserver(userModel)) output.Add("Observer");
             }
+
+            if (IsZLCVisitor(userModel)) output.Add("ZLC Visitor");
 
             if (IsZLCNeighbor(userModel)) output.Add("ZLC Neighbor");
 

--- a/ZLCBotCore/Services/VatsimApiService.cs
+++ b/ZLCBotCore/Services/VatsimApiService.cs
@@ -317,7 +317,7 @@ namespace ZLCBotCore.Services
 
                 if (_message == null) return null;
 
-                if (_message.Author.IsBot && _message.Author.Id == 923302257603252324)
+                if (_message.Author.IsBot && (_message.Author.Id == 923302257603252324 || _message.Author.Id == 1013213129485852672))
                 {
                     botMessageCount++;
                     if (botMessageCount == 1) result = _message;

--- a/ZLCBotCore/ZLCBotCore.csproj
+++ b/ZLCBotCore/ZLCBotCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -18,13 +18,6 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Models\" />
-    <Folder Include="Data\" />
-    <Folder Include="Modules\" />
-    <Folder Include="Services\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
At this moment the bot will check for the following conditions in this order:
`https://api.vatusa.net/v2/user/{DiscordUniqueId}?d` : [Example](https://api.vatusa.net/v2/user/353684697651478528?d) 

---

**1. Is the user's discord connected to VATUSA?**
  - YES : Continue
  - NO`: Send user private discord message with instructions on how to link it. Also, publish embed message inside the assign-roles channel stating it is not linked.

---

**2. Is the user's home facility ZLC?**
  - YES :
    1. Check the user's roles. If the user has ANY of the following, then the "Staff" role will be assigned. If they do not have any of the following roles, do NOT assign them the "Staff" role.
        - `[ "ATM", "DATM", "TA", "EC", "FE", "WM" ]`
    2.  Check the user's "rating_short" for any of the following. If they have any of them, assign them the "ZLC Specialist" role.
        - `[ "S1", "S2", "S3", "C1", "C2", "C3", "I1", "I2", "I3", "SUP" ]`
    3. Check the user's "rating_short" for any of the following. If they have any of them, assign them the "ZLC Observer" role
        - `[ "OBS" ]`
  - NO :
    - Continue

---

**4. Is the user's a registered Visitor to ZLC?**
  - YES : Assign them the "ZLC Visitor" role
  - NO : Continue

---

**5. Is the user's home facility part of the neighboring facilities to ZLC?**
  - YES : Assign them the "ZLC Neighbor" role
  - NO : Continue

---

**6. Does the user have any of the roles mentioned above?**
  - YES : Continue
  - NO : Assign the user the "Guest" role.

---

**NOTE** : If the role names in the ZLC discord change at all, it will require the names to be updated in the code. Also, if any of these role assignments are not needed / wanted, please let me know and I can disable / remove them from the code. 

**NOTE** : This is a slash command. It will show up in the discord as "{BOT NAME} /give-roles". This Slash command will only work inside a text channel named "role-assignment".